### PR TITLE
Add caching for Reverse Geocoding API

### DIFF
--- a/buildTarget.ts
+++ b/buildTarget.ts
@@ -1,6 +1,7 @@
-export const TARGETS = {
-  CHROMIUM: "CHROMIUM",
-  FIREFOX: "FIREFOX",
+export const buildTargets = {
+  chromium: "chrome",
+  firefox: "firefox",
 } as const;
 
-export const buildTarget: keyof typeof TARGETS = TARGETS.CHROMIUM;
+export const buildTarget: (typeof buildTargets)[keyof typeof buildTargets] =
+  buildTargets.chromium;

--- a/dev/commands/chrome/_helpers/getChromeToken.ts
+++ b/dev/commands/chrome/_helpers/getChromeToken.ts
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase */
 
+import { log } from "../../_utils/log";
+
 type AccessToken = string;
 const tokenEndpoint = "https://oauth2.googleapis.com/token";
 
@@ -26,7 +28,7 @@ export const getChromeToken = async (): Promise<AccessToken | void> => {
 
     const data = await response.json();
 
-    console.log("✅ Token refresh succeeded!");
+    log("✅ Token refresh succeeded!");
     return data.access_token;
   } catch (error) {
     throw new Error(`Error refreshing access token: ${error}`);

--- a/src/components/InfoWidget/InfoWidget.tsx
+++ b/src/components/InfoWidget/InfoWidget.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getLocation } from "@/src/services/location";
+import { getGeocodedLocation } from "@/src/services/location";
 import { getWeather } from "@/src/services/weather";
 import { cn } from "@/src/utils";
 
@@ -14,7 +14,7 @@ type Props = {
 
 const InfoWidget = () => {
   const { isError: isLocationError, data: locationData } = useQuery({
-    queryFn: getLocation,
+    queryFn: getGeocodedLocation,
     queryKey: ["location"],
   });
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import type { Manifest } from "webextension-polyfill";
 
-import { TARGETS, buildTarget } from "../buildTarget";
+import { buildTargets, buildTarget } from "../buildTarget";
 import pkg from "../package.json";
 
 const pages = {
@@ -16,7 +16,7 @@ const manifest: Manifest.WebExtensionManifest = {
     default_popup: pages.popup,
   },
   background:
-    buildTarget === TARGETS.FIREFOX
+    buildTarget === buildTargets.firefox
       ? {
           page: pages.background.split(".js")[0] + ".html",
         }
@@ -27,7 +27,7 @@ const manifest: Manifest.WebExtensionManifest = {
   chrome_url_overrides: {
     newtab: pages.new,
   },
-  ...(buildTarget === TARGETS.FIREFOX
+  ...(buildTarget === buildTargets.firefox
     ? {
         chrome_settings_overrides: {
           homepage: pages.new,
@@ -48,7 +48,7 @@ const manifest: Manifest.WebExtensionManifest = {
       resources: ["icon-128.png", "icon-34.png"],
     },
   ],
-  ...(buildTarget === TARGETS.FIREFOX
+  ...(buildTarget === buildTargets.firefox
     ? {
         browser_specific_settings: {
           gecko: {

--- a/src/services/location/getCachedLocation.ts
+++ b/src/services/location/getCachedLocation.ts
@@ -4,8 +4,10 @@ import { Location } from "./types";
 
 const CACHE_DURATION = 20 * 60 * 1000; // 20 minutes
 
-/* Persists the user's lat/long to speed up performance */
-export const checkCachedLatLong = async (): Promise<Location | void> => {
+/**
+ * Persists the user's latitude / longitude to speed up performance
+ */
+export const getCachedLocation = async (): Promise<Location | void> => {
   const { cachedLocation } = await storage.local.get("cachedLocation");
 
   if (!cachedLocation) {

--- a/src/services/location/getCachedReverseGeocoding.ts
+++ b/src/services/location/getCachedReverseGeocoding.ts
@@ -1,0 +1,32 @@
+import { storage } from "webextension-polyfill";
+
+import { GeocodeResponse, Location } from "./types";
+
+/**
+ * Checks a previous reverse geocoding result for lat/long to minimise API calls
+ */
+export const getCachedReverseGeocoding = async ({
+  latitude,
+  longitude,
+}: Location): Promise<GeocodeResponse | void> => {
+  try {
+    const { cachedReverseGeocoding } = await storage.local.get(
+      "cachedReverseGeocoding"
+    );
+
+    if (!cachedReverseGeocoding) {
+      return;
+    }
+
+    if (
+      cachedReverseGeocoding._input?.latitude !== latitude ||
+      cachedReverseGeocoding._input?.longitude !== longitude
+    ) {
+      return;
+    }
+
+    return cachedReverseGeocoding;
+  } catch (error) {
+    throw new Error("Unable to check cached reverse geocoding.");
+  }
+};

--- a/src/services/location/getGeocodedLocation.ts
+++ b/src/services/location/getGeocodedLocation.ts
@@ -1,0 +1,15 @@
+import { getLocation } from "./getLocation";
+import { getReverseGeocoding } from "./getReverseGeocoding";
+import { GeocodedLocation } from "./types";
+
+export const getGeocodedLocation = async (): Promise<GeocodedLocation> => {
+  const { latitude, longitude } = await getLocation();
+  const area = await getReverseGeocoding({ latitude, longitude });
+
+  return {
+    area:
+      area.residential ?? area.municipality ?? area.city_district ?? area.city,
+    latitude,
+    longitude,
+  };
+};

--- a/src/services/location/getLocation.ts
+++ b/src/services/location/getLocation.ts
@@ -1,10 +1,10 @@
 import { storage } from "webextension-polyfill";
 
-import { checkCachedLatLong } from "./checkCachedLatLong";
-import { Area, GeocodeResponse, GeocodedLocation, Location } from "./types";
+import { getCachedLocation } from "./getCachedLocation";
+import { Location } from "./types";
 
-const getLatLong = async (): Promise<Location> => {
-  const cachedLocation = await checkCachedLatLong();
+export const getLocation = async (): Promise<Location> => {
+  const cachedLocation = await getCachedLocation();
 
   if (cachedLocation) {
     return cachedLocation;
@@ -33,30 +33,4 @@ const getLatLong = async (): Promise<Location> => {
       { enableHighAccuracy: false, maximumAge: 3600000, timeout: 5000 }
     );
   });
-};
-
-const getArea = async ({ latitude, longitude }: Location): Promise<Area> => {
-  const res = await fetch(
-    `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json`
-  );
-
-  const data = (await res.json()) as GeocodeResponse;
-
-  if (!data) {
-    return { city: "Unknown location" };
-  }
-
-  return data.address as Area;
-};
-
-export const getLocation = async (): Promise<GeocodedLocation> => {
-  const { latitude, longitude } = await getLatLong();
-  const area = await getArea({ latitude, longitude });
-
-  return {
-    area:
-      area.residential ?? area.municipality ?? area.city_district ?? area.city,
-    latitude,
-    longitude,
-  };
 };

--- a/src/services/location/getReverseGeocoding.ts
+++ b/src/services/location/getReverseGeocoding.ts
@@ -1,0 +1,40 @@
+import { storage } from "webextension-polyfill";
+
+import { getCachedReverseGeocoding } from "./getCachedReverseGeocoding";
+import { Area, GeocodeResponse, Location } from "./types";
+
+export const getReverseGeocoding = async ({
+  latitude,
+  longitude,
+}: Location): Promise<Area> => {
+  const cachedReverseGeocoding = await getCachedReverseGeocoding({
+    latitude,
+    longitude,
+  });
+
+  if (cachedReverseGeocoding) {
+    return cachedReverseGeocoding.address;
+  }
+
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json`
+  );
+
+  const data = (await res.json()) as GeocodeResponse;
+
+  if (!data) {
+    return { city: "Unknown location" };
+  }
+
+  storage.local.set({
+    cachedReverseGeocoding: {
+      _input: {
+        longitude,
+        latitude,
+      },
+      ...data,
+    },
+  });
+
+  return data.address as Area;
+};

--- a/src/services/location/index.ts
+++ b/src/services/location/index.ts
@@ -1,2 +1,2 @@
-export * from "./getLocation";
+export * from "./getGeocodedLocation";
 export * from "./types";

--- a/src/utils/normalizeUrl.ts
+++ b/src/utils/normalizeUrl.ts
@@ -16,7 +16,6 @@ export const normalizeUrl = (url: string) => {
 
     return parsedUrl.href;
   } catch (error) {
-    console.error("Invalid URL:", url);
     return url;
   }
 };

--- a/utils/log.ts
+++ b/utils/log.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 type ColorType = "success" | "info" | "error" | "warning" | keyof typeof COLORS;
 
 export default function colorLog(message: string, type?: ColorType) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
 
-import { TARGETS, buildTarget } from "./buildTarget";
+import { buildTargets, buildTarget } from "./buildTarget";
 import includeChangelog from "./utils/plugins/include-changelog";
 import makeManifest from "./utils/plugins/make-manifest";
 
@@ -12,7 +12,7 @@ const pagesDir = resolve(root, "pages");
 const assetsDir = resolve(root, "assets");
 const outDir = resolve(
   __dirname,
-  buildTarget === TARGETS.FIREFOX ? "dist/firefox" : "dist/chromium"
+  buildTarget === buildTargets.firefox ? "dist/firefox" : "dist/chromium"
 );
 const publicDir = resolve(__dirname, "public");
 
@@ -24,7 +24,7 @@ export default defineConfig({
         background: resolve(
           pagesDir,
           "background",
-          buildTarget === TARGETS.FIREFOX ? "index.html" : "index.ts"
+          buildTarget === buildTargets.firefox ? "index.html" : "index.ts"
         ),
         newtab: resolve(pagesDir, "newtab", "index.html"),
         popup: resolve(pagesDir, "popup", "index.html"),


### PR DESCRIPTION
- The service will now return a cached response if input `longitude, latitude` match. 
- No need to call the API in that case :D 